### PR TITLE
Handling kill signal on prompt

### DIFF
--- a/examplenoise/examplenoise.go
+++ b/examplenoise/examplenoise.go
@@ -11,7 +11,14 @@ func main() {
 	fmt.Println("Welcome to go.linenoise example.")
 	writeHelp()
 	for {
-		str := linenoise.Line("prompt> ")
+		str, err := linenoise.Line("prompt> ")
+		if err != nil {
+			if err == linenoise.KillSignalError {
+				quit()
+			}
+			fmt.Println("Unexpected error: %s", err)
+			quit()
+		}
 		fields := strings.Fields(str)
 
 		// check if there is any valid input at all
@@ -68,13 +75,17 @@ func main() {
 				fmt.Printf("Error on load: %s\n", err)
 			}
 		case "quit":
-			fmt.Println("Thanks for running the go.linenoise example.")
-			fmt.Println("")
-			os.Exit(0)
+			quit()
 		default:
 			writeUnrecognized()
 		}
 	}
+}
+
+func quit() {
+	fmt.Println("Thanks for running the go.linenoise example.")
+	fmt.Println("")
+	os.Exit(0)
 }
 
 func writeHelp() {

--- a/linenoise.go
+++ b/linenoise.go
@@ -24,13 +24,15 @@ func init() {
 func Line(prompt string) (string, error) { // char *linenoise(const char *prompt);
 	promptCString := C.CString(prompt)
 	resultCString := C.linenoise(promptCString)
+	C.free(unsafe.Pointer(promptCString))
+	defer C.free(unsafe.Pointer(resultCString))
+
 	if resultCString == nil {
 		return "", KillSignalError
 	}
-	C.free(unsafe.Pointer(promptCString))
 
 	result := C.GoString(resultCString)
-	C.free(unsafe.Pointer(resultCString)) // TODO: is this required?
+
 	return result, nil
 }
 


### PR DESCRIPTION
Solution for issue #2 
This merge breaks existing API, however, the missing feature can be considered a bug when wrapping linenoise. The KillSignal functionality is essential to linenoise. Users expect to be able to leave with ctrl+C or ctrl+D.
For an example, see examplenoise.
